### PR TITLE
Allow sudo and auto-source setup.bash files

### DIFF
--- a/umrt-build-dev.Dockerfile
+++ b/umrt-build-dev.Dockerfile
@@ -28,4 +28,13 @@ RUN ( \
   ) > /etc/ssh/sshd_config.d/umrt.conf \
   && mkdir /run/sshd
 
+# Automagically source the ros environment for root and user
+RUN --mount=type=secret,id=DEV_USER_NAME ( \
+    echo 'source /opt/ros/humble/setup.bash' \
+    echo 'if [ -f /workspace/install/setup.bash ]; then source /workspace/install/setup.bash; fi' \
+  ) | tee /home/"$(cat /run/secrets/DEV_USER_NAME)"/.bashrc >> /root/.bashrc
+
+# Add user to sudo group
+RUN --mount=type=secret,id=DEV_USER_NAME usermod -aG sudo "$(cat /run/secrets/DEV_USER_NAME)"
+
 ENTRYPOINT /usr/sbin/sshd && /bin/bash


### PR DESCRIPTION
These seem helpful. I end up running these commands every time I open a container/terminal anyways.

I'm sure there is an argument not to source setup.bash every time, but these are still some changes I'd like to see. I am also not sure why not to add the user to sudo group, but you probably had a reason. We can hash it out.